### PR TITLE
CRM_*_Form_*::$_action - Don't redeclare

### DIFF
--- a/CRM/Documents/Form/Document.php
+++ b/CRM/Documents/Form/Document.php
@@ -15,8 +15,6 @@ class CRM_Documents_Form_Document extends CRM_Core_Form {
   
   protected $documentId = false;
   
-  protected $_action;
-  
   protected $context;
   
   protected $entity = false;

--- a/CRM/Documents/Form/NewVersion.php
+++ b/CRM/Documents/Form/NewVersion.php
@@ -15,8 +15,6 @@ class CRM_Documents_Form_NewVersion extends CRM_Core_Form {
   
   protected $documentId = false;
   
-  protected $_action;
-  
   protected $replaceCurrent = false;
   
   function preProcess() {


### PR DESCRIPTION
This property is already declared in the parent class; if upstream makes any
trivial change to it (e.g.  increasing visibility from `protected` to
`public`), then it can break.

For an example script to experiment with PHP property visibility, see:
https://gist.github.com/totten/8a1efedf512add98e3e808796b0eac63

Note: This is a formulaic/untested change since I haven't used the
extension.  Suggested for future-proofing.