### PR TITLE
include date added in tab display; spacing cleanup; fix typo

### DIFF
--- a/CRM/Documents/Page/Versions.php
+++ b/CRM/Documents/Page/Versions.php
@@ -17,7 +17,7 @@ class CRM_Documents_Page_Versions extends CRM_Core_Page {
   function run() {
     $this->preProcess();
     
-    CRM_Utils_System::setTitle(ts("All versios for '".$this->document->getSubject()."'"));
+    CRM_Utils_System::setTitle(ts("All versions for '".$this->document->getSubject()."'"));
     
     $this->assign('versions', $this->document->getVersions());
     

--- a/templates/CRM/Documents/Page/ContactDocuments.tpl
+++ b/templates/CRM/Documents/Page/ContactDocuments.tpl
@@ -1,34 +1,35 @@
 {if $permission EQ 'edit'}
-    {capture assign=newDocumentURL}{crmURL p="civicrm/documents/document" q="reset=1&action=add&cid=`$contactId`"}{/capture}
-    <div class="action-link">
-        <a accesskey="N" href="{$newDocumentURL}" class="button">
-            <span><div class="icon add-icon"></div>{ts}New document{/ts}</span>
-        </a>
-    </div>
-
+  {capture assign=newDocumentURL}{crmURL p="civicrm/documents/document" q="reset=1&action=add&cid=`$contactId`"}{/capture}
+  <div class="action-link">
+    <a accesskey="N" href="{$newDocumentURL}" class="button">
+      <span><div class="icon add-icon"></div>{ts}New document{/ts}</span>
+    </a>
+  </div>
 {/if}
+
 <table>
-    <thead>
-        <tr>
-            <th class="ui-state-default">{ts}Subject{/ts}</th>
-            <th class="ui-state-default">{ts}Contacts{/ts}</th>
-            <th class="ui-state-default">{ts}Date modified{/ts}</th>
-            <th class="ui-state-default">{ts}Modified by{/ts}</th>
-            <th class="no-sort ui-state-default"></th>
-        </tr>
-     </thead>
-     <tbody>
-        
-        {foreach from=$documents item=doc}
-            <tr class="{cycle values="odd,even"}">
-                <td>{$doc->getSubject()}</td>
-                <td>{$doc->getFormattedContacts()}</td>
-                <td>{$doc->getFormattedDateUpdated()}</td>
-                <td>{$doc->getFormattedUpdatedBy()}</td>
-                <td>
-                    {include file=CRM/Documents/actionlinks.tpl}
-                </td>
-            </tr>
-        {/foreach}
-    </tbody>
+  <thead>
+    <tr>
+      <th class="ui-state-default">{ts}Subject{/ts}</th>
+      <th class="ui-state-default">{ts}Contacts{/ts}</th>
+      <th class="ui-state-default">{ts}Date added{/ts}</th>
+      <th class="ui-state-default">{ts}Date modified{/ts}</th>
+      <th class="ui-state-default">{ts}Modified by{/ts}</th>
+      <th class="no-sort ui-state-default"></th>
+    </tr>
+   </thead>
+  <tbody>
+    {foreach from=$documents item=doc}
+      <tr class="{cycle values="odd,even"}">
+        <td>{$doc->getSubject()}</td>
+        <td>{$doc->getFormattedContacts()}</td>
+        <td>{$doc->getFormattedDateAdded()}</td>
+        <td>{$doc->getFormattedDateUpdated()}</td>
+        <td>{$doc->getFormattedUpdatedBy()}</td>
+        <td>
+          {include file=CRM/Documents/actionlinks.tpl}
+        </td>
+      </tr>
+    {/foreach}
+  </tbody>
 </table>


### PR DESCRIPTION
suggested improvements: fixes typo in versions display, adds the Date Added column to main tab listing (currently date added has no exposure), and tidies up the tpl html.