### PR TITLE
Add icon to contact summary tab

### DIFF
--- a/documents.php
+++ b/documents.php
@@ -136,12 +136,15 @@ function documents_civicrm_tabset($path, &$tabs, $context) {
     //Count number of documents
     $documentRepo = CRM_Documents_Entity_DocumentRepository::singleton();
     $DocumentCount = count($documentRepo->getDocumentsByContactId($context['contact_id'], FALSE));
-    
-    $tabs[] = array( 'id'    => 'contact_documents',
-                     'url'   => $url,
-                     'count' => $DocumentCount,
-                     'title' => E::ts('Documents'),
-                     'weight' => 1 );
+
+    $tabs[] = array(
+      'id' => 'contact_documents',
+      'url' => $url,
+      'count' => $DocumentCount,
+      'title' => E::ts('Documents'),
+      'weight' => 1,
+      'icon' => 'crm-i fa-files-o',
+    );
   }
 }
 


### PR DESCRIPTION
Once https://github.com/civicrm/civicrm-core/pull/13018 is merged we can add this icon to the tab. Result will be:

![screenshot from 2018-10-27 09-57-14](https://user-images.githubusercontent.com/2874912/47604987-ba7c5180-d9ce-11e8-993d-62b41e663095.png)
